### PR TITLE
fix(config): accept Nvim 10.x lsp inlay hint API change.

### DIFF
--- a/lua/astrolsp/init.lua
+++ b/lua/astrolsp/init.lua
@@ -85,7 +85,7 @@ M.on_attach = function(client, bufnr)
   if client.supports_method "textDocument/inlayHint" then
     if vim.b[bufnr].inlay_hints == nil then vim.b[bufnr].inlay_hints = M.config.features.inlay_hints end
     -- TODO: remove check after dropping support for Neovim v0.9
-    if vim.lsp.inlay_hint and vim.b[bufnr].inlay_hints then vim.lsp.inlay_hint.enable(bufnr, true) end
+    if vim.lsp.inlay_hint and vim.b[bufnr].inlay_hints then vim.lsp.inlay_hint.enable(true, { bufnr = bufnr }) end
   end
 
   if client.supports_method "textDocument/semanticTokens/full" and vim.lsp.semantic_tokens then

--- a/lua/astrolsp/toggles.lua
+++ b/lua/astrolsp/toggles.lua
@@ -45,7 +45,7 @@ function M.buffer_inlay_hints(bufnr, silent)
   vim.b[bufnr].inlay_hints = not vim.b[bufnr].inlay_hints
   -- TODO: remove check after dropping support for Neovim v0.9
   if vim.lsp.inlay_hint then
-    vim.lsp.inlay_hint.enable(bufnr, vim.b[bufnr].inlay_hints)
+    vim.lsp.inlay_hint.enable(vim.b[bufnr].inlay_hints, { bufnr = bufnr })
     ui_notify(silent, ("Inlay hints %s"):format(bool2str(vim.b[bufnr].inlay_hints)))
   end
 end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
The latest `Neovim` dev version update the inlay-hint API as below image, and this change break the LSP start up, so need to accept the API change.
![image](https://github.com/AstroNvim/astrolsp/assets/18681616/108a72a8-703b-4781-9d87-7c098a1e24a0)

[x] Completed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
N/A
