### PR TITLE
docs(readme): fix formatting issues in config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ local opts = {
     },
   },
   defaults = {
-    hover = { border = "rounded", silent = true } -- customize lsp hover window
+    hover = { border = "rounded", silent = true }, -- customize lsp hover window
     signature_help = false, -- disable any default customizations
   },
   -- Configuration of LSP file operation functionality
@@ -212,7 +212,7 @@ local opts = {
         config = { cmd = { "nextflow-language-server" } }
       }
     }
-  }
+  },
   -- A list like table of servers that should be setup, useful for enabling language servers not installed with Mason.
   servers = { "dartls" },
   -- A custom `on_attach` function to be run after the default `on_attach` function, takes two parameters `client` and `bufnr`  (`:h lspconfig-setup`)


### PR DESCRIPTION
## 📑 Description

Add 2 missing comas in the first config example, resulting in the following errors:
```
E5113: Lua chunk: vim/loader.lua:0: [...]/.config/nvim/lua/lsp.lua:67: '}' expected (to close '{' at line 65) near 'signature_help'
E5113: Lua chunk: vim/loader.lua:0: [...]/.config/nvim/lua/lsp.lua:169: '}' expected (to close '{' at line 2) near 'servers'
```

## 📖 Additional Information

N/A
