### PR TITLE
fix(lsp): preserve client and operation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ local opts = {
     inlay_hints = false, -- enable/disable inlay hints on start
     inline_completion = false, -- enable/disable inline completion capabilities (Neovim v0.12+ ONLY)
     linked_editing_range = false, -- enable/disable linked editing range capabilities (Neovim v0.12+ ONLY)
-    semantic_tokens = true, -- enable/disable semantic token highlighting
+    semantic_tokens = true, -- enable/disable global semantic token highlighting at startup
     signature_help = false, -- enable/disable automatic signature help
   },
   -- Configure buffer local auto commands to add when attaching a language server
   autocmds = {
     -- first key is the `augroup` (:h augroup)
     lsp_document_highlight = {
-      -- condition to create/delete auto command group
+      -- condition to create the auto command group and run its callbacks
       -- can either be a string of a client capability or a function of `fun(client, bufnr): boolean`
-      -- condition will be resolved for each client on each execution and if it ever fails for all clients,
-      -- the auto commands will be deleted for that buffer
+      -- condition will be resolved for each currently attached client on every execution; callbacks are skipped
+      -- while no client matches
       cond = "textDocument/documentHighlight",
       -- list of auto commands to set
       {
@@ -102,9 +102,10 @@ local opts = {
           foldingRange = { dynamicRegistration = false },
         },
       },
-      -- Custom flags table to be passed to all language servers
+      -- Configure the LSP client exit timeout for Neovim v0.11 and v0.12
+      exit_timeout = 5000, -- Neovim v0.12+
       flags = {
-        exit_timeout = 5000,
+        exit_timeout = 5000, -- Neovim v0.11
       },
     },
   },
@@ -147,7 +148,7 @@ local opts = {
     },
     -- default format timeout
     timeout_ms = 1000,
-    -- fully override the default formatting function
+    -- filter the language server clients used for formatting
     filter = function(client) return true end,
   },
   -- Configure how language servers get set up

--- a/lua/astrolsp/config.lua
+++ b/lua/astrolsp/config.lua
@@ -11,7 +11,9 @@
 
 ---@class AstroLSPMapping: vim.api.keyset.keymap
 ---@field [1] string|function? rhs of keymap
+---@field mode? string|string[] mode(s) for the mapping
 ---@field name string? optional which-key mapping name
+---@field group? string|fun():string optional which-key mapping group
 ---@field cond AstroLSPCondition? condition for whether or not to set the mapping during language server attachment
 
 ---@alias AstroLSPMappings table<string,table<string,(AstroLSPMapping|string|false)?>?>
@@ -22,7 +24,7 @@
 
 ---@class AstroLSPAutocmd: vim.api.keyset.create_autocmd
 ---@field event string|string[] Event(s) that will trigger the handler
----@field callback? string|(fun(args:vim.api.keyset.create_autocmd.callback_args,client:vim.lsp.Client,bufnr:integer): boolean?)
+---@field callback? fun(args:vim.api.keyset.create_autocmd.callback_args,client:vim.lsp.Client,bufnr:integer): boolean?
 
 ---@class AstroLSPAutocmds
 ---@field cond AstroLSPCondition? condition for whether or not to create the auto commands during language server attachment
@@ -33,7 +35,7 @@
 ---@field inlay_hints boolean? enable/disable inlay hints on start (boolean; default = false)
 ---@field inline_completion boolean? enable/disable inline completion (boolean; default = false)
 ---@field linked_editing_range boolean? enable/disable linked editing range (boolean; default = false)
----@field semantic_tokens boolean? enable/disable semantic token highlighting (boolean; default = true)
+---@field semantic_tokens boolean? enable/disable global semantic token highlighting at startup (boolean; default = true)
 ---@field signature_help boolean? enable/disable automatic signature help (boolean; default = false)
 
 ---@class AstroLSPFormatOnSaveOpts
@@ -68,14 +70,14 @@
 ---The key into the table is the group name for the auto commands (`:h augroup`) and the value
 ---is a list of autocmd tables where `event` key is the event(s) that trigger the auto command
 ---and the rest are auto command options (`:h nvim_create_autocmd`). A `cond` key can also be
----added to the list to control when an `augroup` should be added as well as deleted if it's never matching
+---added to control when an `augroup` is added and whether its callbacks run for the currently attached clients
 ---Example:
 ---
 ---```lua
 ---autocmds = {
 ---  -- first key is the `augroup` (:h augroup)
 ---  lsp_document_highlight = {
----    -- condition to create/delete auto command group
+---    -- condition to create the auto command group and run its callbacks
 ---    cond = "textDocument/documentHighlight",
 ---    -- list of auto commands to set
 ---    {
@@ -135,7 +137,8 @@
 ---        foldingRange = { dynamicRegistration = false }
 ---      }
 ---    },
----    flags = { exit_timeout = 5000 },
+---    exit_timeout = 5000, -- Neovim v0.12+
+---    flags = { exit_timeout = 5000 }, -- Neovim v0.11
 ---  },
 ---}
 ---```
@@ -200,7 +203,7 @@
 ---  },
 ---  -- default format timeout
 ---  timeout_ms = 1000,
----  -- fully override the default formatting function
+---  -- filter the language server clients used for formatting
 ---  filter = function(client)
 ---    return true
 ---  end
@@ -227,7 +230,7 @@
 ---Example:
 --
 ---```lua
----handlers = {
+---lsp_handlers = {
 ---  ["textDocument/publishDiagnostics"] = my_custom_diagnostics_handler,
 ---}
 ---```

--- a/lua/astrolsp/file_operations.lua
+++ b/lua/astrolsp/file_operations.lua
@@ -15,53 +15,81 @@ local M = {}
 local function get_config() return vim.tbl_get(require "astrolsp", "config", "file_operations") or {} end
 
 ---@class AstroLSPFileOperationsRename
----@field from string the original filename
----@field to string the new filename
+---@field from string|AstroLSPFileOperationPath the original filename
+---@field to string|AstroLSPFileOperationPath the new filename
+---@field kind? "file"|"folder" the renamed item's kind
+
+---@class AstroLSPFileOperationPath
+---@field path string the file or folder path
+---@field kind? "file"|"folder" the path's kind
+
+local function normalize_path(path)
+  if type(path) == "string" then return { path = path } end
+  return path
+end
+
+local function normalize_paths(paths)
+  if type(paths) == "string" or paths.path then return { normalize_path(paths) } end
+  return vim.tbl_map(normalize_path, paths)
+end
+
+local function normalize_renames(renames)
+  if renames.from then renames = { renames } end
+  return vim.tbl_map(function(rename)
+    local from, to = normalize_path(rename.from), normalize_path(rename.to)
+    return {
+      from = from.path,
+      to = to.path,
+      kind = rename.kind or from.kind or to.kind,
+    }
+  end, renames)
+end
 
 local filter_cache = {}
-local match_filters = function(filters, name)
-  local fname = vim.fn.fnamemodify(name, ":p")
+local match_filters = function(filters, file)
+  local fname = vim.fn.fnamemodify(file.path, ":p")
+  local cache_key = fname .. "\0" .. (file.kind or "")
   for _, filter in pairs(filters) do
     if not filter_cache[filter] then filter_cache[filter] = {} end
-    if filter_cache[filter][fname] == nil then
+    if filter_cache[filter][cache_key] == nil then
       local scheme = filter.scheme
-      local cached = { scheme_matches = not scheme or scheme:lower() == "file", matched = false }
+      local matched = false
       local pattern = filter.pattern
       local match_type = pattern.matches
-      local is_dir = string.sub(fname, #fname) == "/"
+      local is_dir = file.kind == "folder" or (file.kind == nil and string.sub(fname, #fname) == "/")
       if
-        cached.scheme_matches
+        (not scheme or scheme:lower() == "file")
         and (not match_type or (match_type == "folder" and is_dir) or (match_type == "file" and not is_dir))
       then
         local regex = vim.fn.glob2regpat(pattern.glob)
         if vim.tbl_get(pattern, "options", "ignoreCase") then regex = "\\c" .. regex end
         local previous_ignorecase = vim.o.ignorecase
         vim.o.ignorecase = false
-        cached.matched = vim.fn.match(fname, regex) ~= -1
+        matched = vim.fn.match(fname, regex) ~= -1
         vim.o.ignorecase = previous_ignorecase
       end
-      filter_cache[filter][fname] = cached
+      filter_cache[filter][cache_key] = matched
     end
-    if filter_cache[filter][fname].matched then return true end
+    if filter_cache[filter][cache_key] then return true end
   end
   return false
 end
 
 --- Notify LSP clients that file(s) were created
----@param fnames string|string[] a file or list of files that were created
+---@param fnames string|AstroLSPFileOperationPath|(string|AstroLSPFileOperationPath)[] a file or list of files that were created
 function M.didCreateFiles(fnames)
   local config = get_config()
   if not vim.tbl_get(config, "operations", "didCreate") then return end
+  local paths = normalize_paths(fnames)
   for _, client in pairs(vim.lsp.get_clients()) do
     local did_create = vim.tbl_get(client, "server_capabilities", "workspace", "fileOperations", "didCreate")
     if did_create then
-      if type(fnames) == "string" then fnames = { fnames } end
       local filters = did_create.filters or {}
-      local filtered = vim.tbl_filter(function(fname) return match_filters(filters, fname) end, fnames)
+      local filtered = vim.tbl_filter(function(path) return match_filters(filters, path) end, paths)
       if next(filtered) then
         client:notify(
           "workspace/didCreateFiles",
-          { files = vim.tbl_map(function(fname) return { uri = vim.uri_from_fname(fname) } end, filtered) }
+          { files = vim.tbl_map(function(path) return { uri = vim.uri_from_fname(path.path) } end, filtered) }
         )
       end
     end
@@ -69,20 +97,20 @@ function M.didCreateFiles(fnames)
 end
 
 --- Notify LSP clients that file(s) were deleted
----@param fnames string|string[] a file or list of files that were deleted
+---@param fnames string|AstroLSPFileOperationPath|(string|AstroLSPFileOperationPath)[] a file or list of files that were deleted
 function M.didDeleteFiles(fnames)
   local config = get_config()
   if not vim.tbl_get(config, "operations", "didDelete") then return end
+  local paths = normalize_paths(fnames)
   for _, client in pairs(vim.lsp.get_clients()) do
     local did_delete = vim.tbl_get(client, "server_capabilities", "workspace", "fileOperations", "didDelete")
     if did_delete ~= nil then
-      if type(fnames) == "string" then fnames = { fnames } end
       local filters = did_delete.filters or {}
-      local filtered = vim.tbl_filter(function(fname) return match_filters(filters, fname) end, fnames)
+      local filtered = vim.tbl_filter(function(path) return match_filters(filters, path) end, paths)
       if next(filtered) then
         client:notify(
           "workspace/didDeleteFiles",
-          { files = vim.tbl_map(function(fname) return { uri = vim.uri_from_fname(fname) } end, filtered) }
+          { files = vim.tbl_map(function(path) return { uri = vim.uri_from_fname(path.path) } end, filtered) }
         )
       end
     end
@@ -94,14 +122,16 @@ end
 function M.didRenameFiles(renames)
   local config = get_config()
   if not vim.tbl_get(config, "operations", "didRename") then return end
+  local normalized_renames = normalize_renames(renames)
   for _, client in pairs(vim.lsp.get_clients()) do
     local did_rename = vim.tbl_get(client, "server_capabilities", "workspace", "fileOperations", "didRename")
     if did_rename ~= nil then
-      if renames.from then renames = { renames } end
       local filters = did_rename.filters or {}
       local filtered = vim.tbl_filter(
-        function(rename) return rename.from and rename.to and match_filters(filters, rename.from) end,
-        renames
+        function(rename)
+          return rename.from and rename.to and match_filters(filters, { path = rename.from, kind = rename.kind })
+        end,
+        normalized_renames
       )
       if next(filtered) then
         client:notify("workspace/didRenameFiles", {
@@ -125,21 +155,21 @@ local function getWorkspaceEdit(client, req, params, timeout)
 end
 
 --- Request workspace edits from LSP clients before file(s) are created
----@param fnames string|string[] a file or list of files that will be created
+---@param fnames string|AstroLSPFileOperationPath|(string|AstroLSPFileOperationPath)[] a file or list of files that will be created
 function M.willCreateFiles(fnames)
   local config = get_config()
   if not vim.tbl_get(config, "operations", "willCreate") then return end
+  local paths = normalize_paths(fnames)
   for _, client in pairs(vim.lsp.get_clients()) do
     local will_create = vim.tbl_get(client, "server_capabilities", "workspace", "fileOperations", "willCreate")
     if will_create then
-      if type(fnames) == "string" then fnames = { fnames } end
       local filters = will_create.filters or {}
-      local filtered = vim.tbl_filter(function(fname) return match_filters(filters, fname) end, fnames)
+      local filtered = vim.tbl_filter(function(path) return match_filters(filters, path) end, paths)
       if next(filtered) then
         local edit = getWorkspaceEdit(
           client,
           "workspace/willCreateFiles",
-          { files = vim.tbl_map(function(fname) return { uri = vim.uri_from_fname(fname) } end, filtered) },
+          { files = vim.tbl_map(function(path) return { uri = vim.uri_from_fname(path.path) } end, filtered) },
           config.timeout
         )
         if edit then vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding) end
@@ -149,21 +179,21 @@ function M.willCreateFiles(fnames)
 end
 
 --- Request workspace edits from LSP clients before file(s) are deleted
----@param fnames string|string[] a file or list of files that will be deleted
+---@param fnames string|AstroLSPFileOperationPath|(string|AstroLSPFileOperationPath)[] a file or list of files that will be deleted
 function M.willDeleteFiles(fnames)
   local config = get_config()
   if not vim.tbl_get(config, "operations", "willDelete") then return end
+  local paths = normalize_paths(fnames)
   for _, client in pairs(vim.lsp.get_clients()) do
     local will_delete = vim.tbl_get(client, "server_capabilities", "workspace", "fileOperations", "willDelete")
     if will_delete then
-      if type(fnames) == "string" then fnames = { fnames } end
       local filters = will_delete.filters or {}
-      local filtered = vim.tbl_filter(function(fname) return match_filters(filters, fname) end, fnames)
+      local filtered = vim.tbl_filter(function(path) return match_filters(filters, path) end, paths)
       if next(filtered) then
         local edit = getWorkspaceEdit(
           client,
           "workspace/willDeleteFiles",
-          { files = vim.tbl_map(function(fname) return { uri = vim.uri_from_fname(fname) } end, filtered) },
+          { files = vim.tbl_map(function(path) return { uri = vim.uri_from_fname(path.path) } end, filtered) },
           config.timeout
         )
         if edit then vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding) end
@@ -177,14 +207,16 @@ end
 function M.willRenameFiles(renames)
   local config = get_config()
   if not vim.tbl_get(config, "operations", "willRename") then return end
+  local normalized_renames = normalize_renames(renames)
   for _, client in pairs(vim.lsp.get_clients()) do
     local will_rename = vim.tbl_get(client, "server_capabilities", "workspace", "fileOperations", "willRename")
     if will_rename then
-      if renames.from then renames = { renames } end
       local filters = will_rename.filters or {}
       local filtered = vim.tbl_filter(
-        function(rename) return rename.from and rename.to and match_filters(filters, rename.from) end,
-        renames
+        function(rename)
+          return rename.from and rename.to and match_filters(filters, { path = rename.from, kind = rename.kind })
+        end,
+        normalized_renames
       )
       if next(filtered) then
         local edit = getWorkspaceEdit(client, "workspace/willRenameFiles", {

--- a/lua/astrolsp/init.lua
+++ b/lua/astrolsp/init.lua
@@ -19,7 +19,9 @@ M.lsp_progress = {}
 --- A table of LSP clients that have been attached with AstroLSP
 M.attached_clients = {}
 
-local function lsp_event(name) vim.api.nvim_exec_autocmds("User", { pattern = "AstroLsp" .. name, modeline = false }) end
+local function lsp_event(name, data)
+  vim.api.nvim_exec_autocmds("User", { pattern = "AstroLsp" .. name, modeline = false, data = data })
+end
 
 ---@param cond? AstroLSPCondition
 ---@param client vim.lsp.Client
@@ -32,16 +34,65 @@ local function check_cond(cond, client, bufnr)
   return true
 end
 
+--- Check whether autoformatting is enabled for a buffer
+---@param bufnr? integer The buffer to check, default the current buffer
+---@return boolean enabled Whether autoformatting is enabled
+function M.autoformat_enabled(bufnr)
+  bufnr = bufnr or 0
+  local buffer_autoformat = vim.b[bufnr].autoformat
+  if buffer_autoformat ~= nil then return buffer_autoformat end
+
+  local autoformat = assert(M.config.formatting.format_on_save)
+  if type(autoformat) == "boolean" then return autoformat end
+  local filetype = vim.bo[bufnr].filetype
+  return autoformat.enabled == true
+    and (type(autoformat.filter) ~= "function" or autoformat.filter(bufnr))
+    and (tbl_isempty(autoformat.allow_filetypes or {}) or tbl_contains(autoformat.allow_filetypes, filetype))
+    and (tbl_isempty(autoformat.ignore_filetypes or {}) or not tbl_contains(autoformat.ignore_filetypes, filetype))
+end
+
+--- Check whether a buffer has an LSP client available for autoformatting
+---@param bufnr? integer The buffer to check, default the current buffer
+---@return boolean available Whether autoformatting can be toggled for the buffer
+function M.autoformat_available(bufnr)
+  bufnr = bufnr or 0
+  local formatting_disabled = M.config.formatting.disabled or {}
+  if formatting_disabled == true then return false end
+  for _, client in pairs(vim.lsp.get_clients { bufnr = bufnr }) do
+    if
+      client:supports_method("textDocument/formatting", bufnr) and not tbl_contains(formatting_disabled, client.name)
+    then
+      return true
+    end
+  end
+  return false
+end
+
 --- Add a new LSP progress message to the message queue
 ---@param data {client_id: integer, params: lsp.ProgressParams}
 function M.progress(data)
-  local id = ("%s.%s"):format(data.client_id, data.params.token)
-  M.lsp_progress[id] = M.lsp_progress[id] and vim.tbl_deep_extend("force", M.lsp_progress[id], data.params.value)
-    or data.params.value
-  if not M.lsp_progress[id] or M.lsp_progress[id].kind == "end" then
+  local id = ("%s.%s.%s"):format(data.client_id, type(data.params.token), data.params.token)
+  local value = data.params.value
+  if type(value) == "table" then
+    for key, val in pairs(value) do
+      if val == vim.NIL then value[key] = nil end
+    end
+  end
+  local progress
+  if not value or value.kind == "begin" then
+    progress = value
+  elseif M.lsp_progress[id] then
+    progress = vim.tbl_deep_extend("force", M.lsp_progress[id], value)
+  else
+    progress = value
+  end
+  M.lsp_progress[id] = progress
+  if not progress or progress.kind == "end" then
     vim.defer_fn(function()
-      M.lsp_progress[id] = nil
-      lsp_event "Progress"
+      if M.lsp_progress[id] == progress then
+        M.lsp_progress[id] = nil
+        lsp_event "Progress"
+      end
     end, 100)
   end
   lsp_event "Progress"
@@ -72,10 +123,7 @@ function M.add_on_attach(on_attach, opts)
   )
 end
 
---- The `on_attach` function used by AstroNvim
----@param client vim.lsp.Client The LSP client details when attaching
----@param bufnr integer The buffer that the LSP client is attaching to
-function M.on_attach(client, bufnr)
+local function configure_buffer(client, bufnr)
   -- TODO: remove check when dropping support for Neovim v0.11
   if
     client:supports_method("textDocument/codeLens", bufnr)
@@ -85,26 +133,20 @@ function M.on_attach(client, bufnr)
     vim.lsp.codelens.refresh { bufnr = bufnr }
   end
 
-  local formatting_disabled = vim.tbl_get(M.config, "formatting", "disabled")
-  if
-    client:supports_method("textDocument/formatting", bufnr)
-    and (formatting_disabled ~= true and not tbl_contains(formatting_disabled, client.name))
-  then
-    local autoformat = assert(M.config.formatting.format_on_save)
-    local filetype = vim.bo[bufnr].filetype
-    if vim.b[bufnr].autoformat == nil then
-      vim.b[bufnr].autoformat = autoformat.enabled
-        and (tbl_isempty(autoformat.allow_filetypes or {}) or tbl_contains(autoformat.allow_filetypes, filetype))
-        and (tbl_isempty(autoformat.ignore_filetypes or {}) or not tbl_contains(autoformat.ignore_filetypes, filetype))
-    end
-  end
-
   -- TODO: remove when dropping support for Neovim v0.11
   if client:supports_method("textDocument/semanticTokens/full", bufnr) and not vim.lsp.semantic_tokens.enable then
-    if M.config.features.semantic_tokens then
-      if vim.b[bufnr].semantic_tokens == nil then vim.b[bufnr].semantic_tokens = true end
-    else
+    if M.config.features.semantic_tokens == false then
       client.server_capabilities.semanticTokensProvider = nil
+    elseif vim.b[bufnr].semantic_tokens == nil then
+      vim.b[bufnr].semantic_tokens = true
+    elseif vim.b[bufnr].semantic_tokens == false then
+      vim.schedule(function()
+        vim.schedule(function()
+          if vim.api.nvim_buf_is_valid(bufnr) and vim.b[bufnr].semantic_tokens == false then
+            pcall(vim.lsp.semantic_tokens.stop, bufnr, client.id)
+          end
+        end)
+      end)
     end
   end
 
@@ -133,6 +175,7 @@ function M.on_attach(client, bufnr)
             autocmd.command, autocmd.event = nil, nil
             autocmd.group, autocmd.buffer = group, bufnr
             local callback_func = command and function(_, _, _) vim.cmd(command) end or callback
+            ---@cast callback_func function
             autocmd.callback = function(args)
               local callback_client
               for _, cb_client in ipairs(vim.lsp.get_clients { bufnr = bufnr }) do
@@ -168,6 +211,7 @@ function M.on_attach(client, bufnr)
             map_opts = assert(vim.tbl_deep_extend("force", map_opts, { buffer = bufnr }))
             map_opts[1], map_opts.cond = nil, nil
           end
+          ---@cast map_opts AstroLSPMapping
           if rhs then
             vim.keymap.set(mode, lhs, rhs, map_opts --[[@as vim.keymap.set.Opts]])
           elseif wk_avail then
@@ -179,9 +223,14 @@ function M.on_attach(client, bufnr)
       end
     end
   end
+end
 
+--- The `on_attach` function used by AstroNvim
+---@param client vim.lsp.Client The LSP client details when attaching
+---@param bufnr integer The buffer that the LSP client is attaching to
+function M.on_attach(client, bufnr)
+  configure_buffer(client, bufnr)
   if type(M.config.on_attach) == "function" then M.config.on_attach(client, bufnr) end
-
   if not M.attached_clients[client.id] then M.attached_clients[client.id] = client end
 end
 
@@ -222,17 +271,18 @@ function M.setup(opts)
   normalize_mappings(M.config.mappings)
   normalize_mappings(opts.mappings)
   -- TODO: remove when dropping support for Neoivm v0.11
-  local extend_method = "force"
   if vim.fn.has "nvim-0.12" == 1 then
-    extend_method = function(key, prev_value, value)
+    ---@diagnostic disable-next-line: param-type-mismatch
+    M.config = vim.tbl_deep_extend(function(key, prev_value, value)
       if key == "servers" then
         if type(value) == "table" and type(prev_value) == "table" then return unique_list(prev_value, value) end
       end
       return value
-    end
+    end, M.config, opts)
+  else
+    M.config = vim.tbl_deep_extend("force", M.config, opts)
+    M.config.servers = unique_list(M.config.servers)
   end
-  M.config = vim.tbl_deep_extend(extend_method, M.config, opts)
-  if extend_method == "force" then M.config.servers = unique_list(M.config.servers) end
 
   -- enable necessary capabilities for enabled LSP file operations
   local fileOperations = vim.tbl_get(M.config, "file_operations", "operations")
@@ -272,10 +322,9 @@ function M.setup(opts)
     end,
   })
 
-  -- normalize format_on_save to table format
-  if vim.tbl_get(M.config, "formatting", "format_on_save") == false then
-    M.config.formatting.format_on_save = { enabled = false }
-  end
+  -- normalize boolean format_on_save values to table format
+  local format_on_save = vim.tbl_get(M.config, "formatting", "format_on_save")
+  if type(format_on_save) == "boolean" then M.config.formatting.format_on_save = { enabled = format_on_save } end
 
   --- Format options that are passed into the `vim.lsp.buf.format` (`:h vim.lsp.buf.format()`)
   ---@type AstroLSPFormatOpts
@@ -337,7 +386,7 @@ function M.setup(opts)
       if client.id ~= excluded_client_id and client:supports_method("textDocument/signatureHelp", bufnr) then
         add_options(client.server_capabilities.signatureHelpProvider)
         if client._get_registrations then
-          for _, registration in ipairs(client:_get_registrations("textDocument/signatureHelp", bufnr) or {}) do
+          for _, registration in ipairs(client:_get_registrations("signatureHelpProvider", bufnr) or {}) do
             add_options(registration.registerOptions)
           end
         else
@@ -405,8 +454,9 @@ function M.setup(opts)
     local client = vim.lsp.get_client_by_id(ctx.client_id)
     if client then
       for bufnr, _ in pairs(client.attached_buffers) do
-        M.on_attach(client, bufnr)
+        configure_buffer(client, bufnr)
         refresh_signature_help_triggers(bufnr)
+        lsp_event("Capability", { client_id = client.id, bufnr = bufnr })
       end
     end
     return ret
@@ -419,6 +469,7 @@ function M.setup(opts)
     if client then
       for bufnr, _ in pairs(client.attached_buffers) do
         refresh_signature_help_triggers(bufnr)
+        lsp_event("Capability", { client_id = client.id, bufnr = bufnr })
       end
     end
     return ret

--- a/lua/astrolsp/toggles.lua
+++ b/lua/astrolsp/toggles.lua
@@ -27,11 +27,13 @@ end
 ---@param silent? boolean if true then don't send a notification
 function M.buffer_autoformat(bufnr, silent)
   bufnr = bufnr or 0
+  local astrolsp = require "astrolsp"
   local old_val = vim.b[bufnr].autoformat
-  if old_val == nil then
+  if not astrolsp.autoformat_available(bufnr) then
     ui_notify(silent, "No LSP attached with auto formatting")
     return
   end
+  if old_val == nil then old_val = astrolsp.autoformat_enabled(bufnr) end
   vim.b[bufnr].autoformat = not old_val
   ui_notify(silent, ("Buffer autoformatting %s"):format(bool2str(vim.b[bufnr].autoformat)))
 end
@@ -61,6 +63,10 @@ end
 ---@param silent? boolean if true then don't send a notification
 function M.buffer_semantic_tokens(bufnr, silent)
   bufnr = bufnr or 0
+  if get_config().features.semantic_tokens == false then
+    ui_notify(silent, "Semantic token highlighting is disabled globally", vim.log.levels.WARN)
+    return
+  end
   if vim.lsp.semantic_tokens.enable then
     vim.lsp.semantic_tokens.enable(not vim.lsp.semantic_tokens.is_enabled { bufnr = bufnr }, { bufnr = bufnr })
     vim.lsp.semantic_tokens.force_refresh(bufnr)
@@ -90,6 +96,7 @@ function M.semantic_tokens(silent)
     return
   end
   vim.lsp.semantic_tokens.enable(not vim.lsp.semantic_tokens.is_enabled())
+  get_config().features.semantic_tokens = vim.lsp.semantic_tokens.is_enabled()
   vim.lsp.semantic_tokens.force_refresh()
   ui_notify(silent, ("Global lsp semantic highlighting %s"):format(bool2str(vim.lsp.semantic_tokens.is_enabled())))
 end


### PR DESCRIPTION
**Client lifecycle**

- Prevent repeated attachment callbacks and preserve progress, formatting, command, and autocommand state.
- Refresh dynamic capabilities and signature triggers as clients register and unregister features.

**Operations and compatibility**

- Preserve file and folder operation filters, and enforce semantic-token policy across Neovim 0.11 and 0.12.
- Correct related docs and mapping/merge annotations.

**Validation**

- Passed StyLua, Selene, typos, diff checks, focused runtime tests, and a full tracked-source LuaLS audit.
